### PR TITLE
bug: fix a crash occurring during the loading of a battle after reloading a save (#13)

### DIFF
--- a/Bannerlord.ExpandedTemplate.Integration/SubModule.cs
+++ b/Bannerlord.ExpandedTemplate.Integration/SubModule.cs
@@ -134,7 +134,7 @@ namespace Bannerlord.ExpandedTemplate.Integration
 
         private void AddEquipmentSpawnMissionBehaviour(Mission mission)
         {
-            _equipmentSetterMissionLogic ??= InstantiateSpawnEquipmentMissionLogic();
+            _equipmentSetterMissionLogic = InstantiateSpawnEquipmentMissionLogic();
             mission.AddMissionBehavior(_equipmentSetterMissionLogic);
         }
 

--- a/build/common.props
+++ b/build/common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BuildVersion>1.1.3</BuildVersion>
+    <BuildVersion>1.1.4</BuildVersion>
     <GameVersion>1.2.12</GameVersion>
   </PropertyGroup>
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.4
+Game Versions: v1.2.11,v1.2.12
+
+Bug Fixes:
+* Fixed a crash occurring during the loading of a battle after reloading a save.
+---------------------------------------------------------------------------------------------------
 Version: 1.1.3
 Game Versions: v1.2.11,v1.2.12
 


### PR DESCRIPTION
The EquipmentSetterMissionLogic object relies on Bannerlord's MbObjectManager instance. A new instance is created on every campaign save reload. Since we instantiated _equipmentSetterMissionLogic only once, we still used the old instance after a reload. Hence, the game crashing on the next battle after the old instance has been garbage-collected.